### PR TITLE
Documentation for hardcoded config check

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -17,9 +17,8 @@ Validate the install using `--version`. flake8-flask adds two plugins, but this 
 
 ## List of warnings
 
-**R2C202**: `need-filename-or-mimetype-for-file-objects-in-send-file`: This check detects the use of a file-like object in `flask.send_file` without either `mimetype` or `attachment_filename` keyword arguments. `send_file` will throw a ValueError in this situation.
+- **R2C202**: `need-filename-or-mimetype-for-file-objects-in-send-file`: This check detects the use of a file-like object in `flask.send_file` without either `mimetype` or `attachment_filename` keyword arguments. `send_file` will throw a ValueError in this situation.
 
-**R2C203**: `secure-set-cookie`: This check detects calls to `response.set_cookie` that do not have `secure`, `httponly`, and `samesite` set. This follows the [guidance in the Flask documentation](https://flask.palletsprojects.com/en/1.1.x/security/#set-cookie-options).
+- **R2C203**: `secure-set-cookie`: This check detects calls to `response.set_cookie` that do not have `secure`, `httponly`, and `samesite` set. This follows the [guidance in the Flask documentation](https://flask.palletsprojects.com/en/1.1.x/security/#set-cookie-options).
 
-
-
+- `avoid-hardcoded-env-variables`: This check detect and discourages hardcoded usages of `ENV`, `DEBUG`, `TESTING`, and `SECRET_KEY` variables. This follows [Flask Configuration](https://flask.palletsprojects.com/en/1.1.x/config/?highlight=configuration#environment-and-debug-features) and [Flask Best Practices](https://flask.palletsprojects.com/en/1.1.x/config/?highlight=configuration#configuration-best-practices) guidelines.

--- a/docs/warnings/avoid_hardcoded_config.md
+++ b/docs/warnings/avoid_hardcoded_config.md
@@ -1,0 +1,60 @@
+
+# avoid-hardcoded-config
+
+From [builtin config variables](https://flask.palletsprojects.com/en/1.1.x/config/?highlight=configuration#builtin-configuration-values), this check discourages hardcoded usages of `ENV`, `DEBUG`, `TESTING`, and `SECRET_KEY` variables.
+
+
+## Description
+
+[Flask Configuration](https://flask.palletsprojects.com/en/1.1.x/config/?highlight=configuration#environment-and-debug-features) recommends using OS environment variables to setup up *Flask* config variables and strongly discourage hardcoding it because such hardcoded values can’t be read early by the flask command, and some systems or extensions may have already configured themselves based on a previous value.
+
+The reason `ENV`, `DEBUG`, `TESTING` variables are selected among 29 builtin variables is that they enable environment and debug features that are used among almost all flask applications. `SECRET_KEY` is related to the sessions cookie and hardcoding it is a security vulnerability [CWE-798](https://cwe.mitre.org/data/definitions/798.html).
+
+This check will alert on these cases, for example:
+
+``` python
+# SHOULD MATCH
+
+# For `TESTING`
+app.config["TESTING"] = True
+app.config["TESTING"] = False
+app.config.update(TESTING=True)
+
+# For `SECRET_KEY`
+app.config.update(SECRET_KEY="aaaa")
+app.config["SECRET_KEY"] = b'_5#y2L"F4Q8z\n\xec]/'
+
+# For `ENV`
+app.config["ENV"] = "development"
+app.config["ENV"] = "production"
+
+# For `DEBUG`
+app.config["DEBUG"] = True
+app.config["DEBUG"] = False
+app.run(debug=True)
+```
+
+This check will _not_ alert on these cases:
+
+``` python
+# SHOULD NOT MATCH
+# For `TESTING`
+app.config["TESTING"] = os.getenv("TESTING")
+app.config["TESTING"] = "aa"
+
+# For `SECRET_KEY`
+app.config.update(SECRET_KEY=os.getenv("SECRET_KEY"))
+app.config.update(SECRET_KEY=os.environ["SECRET_KEY"])
+
+# FOR `ENV`
+app.config["ENV"] = os.environ["development"]
+
+# For `DEBUG`
+app.config["DEBUG"] = os.environ["DEBUG"] or True
+app.config["DEBUG"] = os.environ["DEBUG"] or False
+app.run(debug=os.getenv("DEBUG", True))
+```
+
+## References
+1. https://flask.palletsprojects.com/en/1.1.x/config/?highlight=configuration#builtin-configuration-values
+2. https://flask.palletsprojects.com/en/1.1.x/config/?highlight=configuration#environment-and-debug-features


### PR DESCRIPTION
Adds documentataion for `avoid_hardcoded_config` based on https://github.com/returntocorp/bento-core/issues/169

<img width="1220" alt="Screen Shot 2019-11-15 at 1 48 49 PM" src="https://user-images.githubusercontent.com/1626382/68978099-b58f6900-07ae-11ea-9394-12057fc17eeb.png">

<img width="923" alt="Screen Shot 2019-11-15 at 1 42 54 PM" src="https://user-images.githubusercontent.com/1626382/68977931-57628600-07ae-11ea-9d9f-d33647b621da.png">
