### PR TITLE
Add Google Analytics to checks

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,3 +8,4 @@ theme:
     secondary: "indigo"
 markdown_extensions:
   - codehilite
+google_analytics: ["UA-106134149-11", "checks.bento.dev"]


### PR DESCRIPTION
This uses the same GA ID as bento.dev and cross-subdomain tracking is configured on the GA side